### PR TITLE
Fix FindViewById null result

### DIFF
--- a/Droid/MainActivity.cs
+++ b/Droid/MainActivity.cs
@@ -9,24 +9,22 @@ namespace Samples.Droid
     [Activity(Label = "Samples.Droid", Icon = "@drawable/icon", Theme = "@style/MyTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation)]
     public class MainActivity : global::Xamarin.Forms.Platform.Android.FormsAppCompatActivity
     {
-        public static Android.Support.V7.Widget.Toolbar ToolBar { get; private set; }
+        public static Android.Support.V7.Widget.Toolbar ToolBar { get; set; }
+
+        public static MainActivity Current{ get; set; }
 
         protected override void OnCreate(Bundle bundle)
         {
             TabLayoutResource = Resource.Layout.Tabbar;
             ToolbarResource = Resource.Layout.Toolbar;
 
+            Current = this as MainActivity;
+
             base.OnCreate(bundle);
 
             global::Xamarin.Forms.Forms.Init(this, bundle);
 
             LoadApplication(new App());
-        }
-
-        public override bool OnCreateOptionsMenu(IMenu menu)
-        {
-            ToolBar = FindViewById<Android.Support.V7.Widget.Toolbar>(Resource.Id.toolbar);
-            return base.OnCreateOptionsMenu(menu);
         }
     }
 }

--- a/Droid/SearchPageRenderer.cs
+++ b/Droid/SearchPageRenderer.cs
@@ -1,5 +1,6 @@
 ﻿using Android.Runtime;
 using Android.Text;
+using Android.Views;
 using Android.Views.InputMethods;
 using Samples.CustomRenderers;
 using Samples.Droid.CustomRenderer;
@@ -23,6 +24,15 @@ namespace Samples.Droid.CustomRenderer
                 return;
             }
 
+            var inflater = LayoutInflater.From(MainActivity.Current);
+
+            var toolbarView = inflater.Inflate(Resource.Layout.Toolbar, null);
+            var toolbar = MainActivity.Current.FindViewById<Android.Support.V7.Widget.Toolbar>(toolbarView.Id);
+
+            MainActivity.ToolBar = toolbar;
+
+            MainActivity.ToolBar = FindViewById<Android.Support.V7.Widget.Toolbar>(Resource.Id.toolbar);
+
             AddSearchToToolBar();
         }
 
@@ -30,8 +40,8 @@ namespace Samples.Droid.CustomRenderer
         {
             if (_searchView != null)
             {
-                _searchView.QueryTextChange += searchView_QueryTextChange;
-                _searchView.QueryTextSubmit += searchView_QueryTextSubmit;
+                _searchView.QueryTextChange -= searchView_QueryTextChange;
+                _searchView.QueryTextSubmit -= searchView_QueryTextSubmit;
             }
             MainActivity.ToolBar?.Menu?.RemoveItem(Resource.Menu.mainmenu);
             base.Dispose(disposing);


### PR DESCRIPTION
* MainActivity.cs: Removed OnOptionsMenuCreated event as it doesn't work for latest android versions. Moved FindViewById call to SearchPageRenderer.cs
* SearchPageRenderer.cs: FindViewById for toolbar now called from pageOnElementChanged event. Use LayoutInflator to get toolbar instead of null from FindViewById method